### PR TITLE
Frontify/frontify-aem-connector#7 make sure encoded category is treated as a string

### DIFF
--- a/ui.frontend/src/main/webpack/site/components/ffy-dam-author-panel.js
+++ b/ui.frontend/src/main/webpack/site/components/ffy-dam-author-panel.js
@@ -75,7 +75,7 @@ function cleanUpDataAssets(data) {
             return element;
           }
         }
-        
+
     });
     return cleanAssets;
 }
@@ -102,7 +102,7 @@ async function handleUpdateAssetList(endpoint, domain) {
         }
       }
     }
-    project(id: $category) {
+    project(id: "$category") {
       ... on MediaLibrary {
         id
         name

--- a/ui.frontend/src/main/webpack/site/components/ffy-filter.js
+++ b/ui.frontend/src/main/webpack/site/components/ffy-filter.js
@@ -38,12 +38,12 @@ export async function handleUpdateCategoriesList(endpoint, domain, callback) {
         }
         if (data != null || data != undefined) {
             sessionStorage.setItem("ffy.categories", JSON.stringify(data));
-            localCategories = JSON.stringify(data);           
+            localCategories = JSON.stringify(data);
         } else {
             $(window).adaptTo("foundation-ui").alert("Error", "Error obtaining categories");
         }
     }
-    
+
     if (localCategories != null && localCategories != undefined) {
         var categoriesListSelectHidden = $("#frontifyfilter_type_selector");
 
@@ -58,24 +58,23 @@ export async function handleUpdateCategoriesList(endpoint, domain, callback) {
                     text: brand.name + ' -  ' + item.name
                 }));
             }
-        } 
+        }
     }
 
-    if (sessionStorage.getItem("ffy.chosenCategory") != null) {
-        var selectedValue = sessionStorage.getItem("ffy.chosenCategory");
-        $("#frontifyfilter_type_selector coral-select-item[value=" + sessionStorage.getItem("ffy.chosenCategory") + "]").attr('selected', 'selected');
-        $("#frontifyfilter_type_selector coral-select-item[value=" + sessionStorage.getItem("ffy.chosenCategory") + "]").change();
-    } else {
-        var firstProjectId = JSON.parse(sessionStorage.getItem("ffy.categories")).brands[0].projects[0].id;
-        $("#frontifyfilter_type_selector coral-select-item[value=" + firstProjectId + "]").attr('selected', 'selected');
-        $("#frontifyfilter_type_selector coral-select-item[value=" + firstProjectId + "]").change();
+        if (sessionStorage.getItem("ffy.chosenCategory") != null) {
+            var selectedValue = sessionStorage.getItem("ffy.chosenCategory");
+            $("#frontifyfilter_type_selector coral-select-item[value='" + sessionStorage.getItem("ffy.chosenCategory") + "']").attr('selected', 'selected');
+            $("#frontifyfilter_type_selector coral-select-item[value='" + sessionStorage.getItem("ffy.chosenCategory") + "']").change();
+        } else {
+            var firstProjectId = JSON.parse(sessionStorage.getItem("ffy.categories")).brands[0].projects[0].id;
+            $("#frontifyfilter_type_selector coral-select-item[value='" + firstProjectId + "']").attr('selected', 'selected');
+            $("#frontifyfilter_type_selector coral-select-item[value='" + firstProjectId + "']").change();
 
     }
-    
+
     callback(endpoint, domain);
 
     }
-
 
 
 }


### PR DESCRIPTION
The category id Base64 encoded and "can" end with a '=' character, which was throwing errors both in the graphQL qery and in jQuery selectors. 
Added String delimiters to guarantee the value is understood properly.