### PR TITLE
disable mvn baseline versioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,11 @@ Bundle-DocURL:
                     <groupId>biz.aQute.bnd</groupId>
                     <artifactId>bnd-baseline-maven-plugin</artifactId>
                     <version>${bnd.version}</version>
+                    <configuration>
+                        <diffignores>
+                           <diffignore>Bundle-Version</diffignore>
+                        </diffignores>
+                    </configuration>
                 </plugin>
                 <!-- Maven Resources Plugin -->
                 <plugin>


### PR DESCRIPTION
because we don't use standard versioning, there is an error from maven when we try to deploy new release, looks something like this: [ERROR] The bundle version change (6.5.4-2.0.1 to 6.5.4-2.0.2) is too low, the new version must be at least 6.5.5
