### PR TITLE
Fixes #27 removing additional query parameters from images

### DIFF
--- a/ui.frontend/src/main/webpack/site/components/ffy-dam-author-panel.js
+++ b/ui.frontend/src/main/webpack/site/components/ffy-dam-author-panel.js
@@ -54,7 +54,7 @@ function renderAssets(frontifyAssets) {
             &quot;./id&quot;:&quot;${frontifyAsset.id}&quot;, 
             &quot;./description&quot;:&quot;${frontifyAsset.description}&quot;,
             &quot;./focalPoint&quot;:&quot;${focalPoint}&quot;}"
-                                data-path=${frontifyAsset.imagePreviewUrl} data-asset-group="ffymedia"
+                                data-path=${frontifyAsset.previewUrl} data-asset-group="ffymedia"
                                 data-type="Images"
                                 data-asset-mimetype="${typename}/${frontifyAsset.extension}">
                         <coral-card-asset>


### PR DESCRIPTION
Image preview had a predefined width which didn't allow the resizing of the AEM Image component when configuring a different image size. 